### PR TITLE
Add easier logging capability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "FitBit OAuth 2.0 Client Library based heavily upon djchen/oauth2-fitbit & heyitspavel/fitbitphp",
     "license": "MIT",
     "require": {
-        "league/oauth2-client": "~1.2"
+        "league/oauth2-client": "~1.2",
+        "psr/log" : "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Instead of doing calls to `error_log` I added this so that users can use standard PSR-3 loggers.

To there isn't much by way of logging though so this isn't really a big deal.

Also, even if you don't accept this, where is the declaration for `::DEBUG` anyway?
