### PR TITLE
Token refresh notifications + more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "require": {
         "league/oauth2-client": "~1.2",
-        "psr/log" : "^1.0"
+        "psr/log" : "^1.0",
+        "sabre/event": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/FitbitPHPOAuth2.php
+++ b/src/FitbitPHPOAuth2.php
@@ -3,6 +3,8 @@
 namespace brulath\fitbit;
 
 use League\OAuth2\Client\Token\AccessToken;
+use Sabre\Event\EventEmitterInterface;
+use Sabre\Event\EventEmitterTrait;
 
 /**
  * Fitbit PHP Oauth2 v.1.0.0 Basic Fitbit API wrapper for PHP using OAuth
@@ -15,7 +17,10 @@ use League\OAuth2\Client\Token\AccessToken;
  * @version 1.0.0 ($Id$)
  * @license http://opensource.org/licenses/MIT MIT
  */
-class FitbitPHPOAuth2 {
+class FitbitPHPOAuth2 implements EventEmitterInterface {
+
+    use EventEmitterTrait;
+
     const API_URL = 'https://api.fitbit.com/1/';
 
     /**
@@ -108,6 +113,7 @@ class FitbitPHPOAuth2 {
         }
         $refresh_token = $this->access_token->getRefreshToken();
         $this->access_token = $this->provider->getAccessToken('refresh_token', ['refresh_token' => $refresh_token]);
+        $this->emit('refresh-token', [ $this->access_token ]);
         $this->debug("Received new access_token: " . print_r($this->access_token, true));
     }
 
@@ -185,6 +191,7 @@ class FitbitPHPOAuth2 {
         } else {
             unset($_SESSION['fitbit-php-oauth2-state']);
             $this->access_token = $this->provider->getAccessToken('authorization_code', ['code' => $_GET['code']]);
+            $this->emit('obtain-token', [ $this->access_token ]);
         }
     }
 


### PR DESCRIPTION
Emits evens on obtaining and refreshing tokens.

For example you can do:

``` php
$fibit->on('obtain-token', function(AccessToken $token) {
   // ... first time new token, save or whatever you need to do with the token
});

$fibit->on('refresh-token', function(AccessToken $token) {
   // ... re-save or whatever you need to do with the token
});
```

Also a minor improvement to `processRequest`
